### PR TITLE
Issue 66

### DIFF
--- a/common/src/main/scala/com/goldblastgames/themole/skills/SkillTracker.scala
+++ b/common/src/main/scala/com/goldblastgames/themole/skills/SkillTracker.scala
@@ -20,7 +20,7 @@ class SkillTracker(sources: Map[Player, Event[SubmitCommand]], missionTracker: M
   // A behaviour[int] that is always zero
   val zero: Behaviour[Int] = new Constant(0)
 
-    // Behaviours for each submitted skill of each player
+  // Behaviours for each submitted skill of each player
   val submittedSkills: Map[Nation, Map[Skill, Map[Player, Behaviour[Int]]]] =
     Nation.values.map {
       case nation => {

--- a/server/src/main/scala/com/goldblastgames/themole/Server.scala
+++ b/server/src/main/scala/com/goldblastgames/themole/Server.scala
@@ -159,7 +159,7 @@ object Server extends EchoApp {
 
       // Join all the resulting streams and output them.
       val output = join(chatOutput, missionOutput, deadDropOutput, dmOutput)
-      
+
       // Log the raw output.
       output.foreach { case (player, connection) =>
         connection.foreach(msg => println("Raw to %s: %s".format(player, msg)))


### PR DESCRIPTION
player skill tracking complete, but skills regenerate by 2 immediately after each mission rather than 1 after the mission and one half way to the next mission.  This resolves timing nondeterministic timing issues caused by having two timer tasks.  Currently this has no affect on gameplay, but if we need skills to regenerate evenly over time we can replace TimedMissionChange which a TimedRegeneration which happens twice as often and filter out every other for use as the mission timer
